### PR TITLE
Add rank list modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -299,6 +299,7 @@
             <section id="progression" class="content-section">
                 <div class="progression-container">
                     <h2>Progression & Statistiques</h2>
+                    <button onclick="app.showRankList()" class="rank-btn">Rangs et Titres</button>
                     <div class="progression-content" id="progressionContent">
                         <!-- Contenu généré dynamiquement -->
                     </div>

--- a/script.js
+++ b/script.js
@@ -404,8 +404,9 @@ class MyRPGLife {
         this.data.totalXP += amount;
         this.data.dailyXP += amount;
         
-        // Ajouter à l'activité récente
-        this.addRecentActivity(`+${amount} XP`, reason);
+        // Ajouter à l'activité récente en formatant le signe correctement
+        const formatted = amount >= 0 ? `+${amount}` : `${amount}`;
+        this.addRecentActivity(`${formatted} XP`, reason);
         
         const newRank = this.getCurrentRank();
         
@@ -782,6 +783,25 @@ class MyRPGLife {
                 </div>
             `;
         }
+    }
+
+    showRankList() {
+        const modal = this.createModal('Rangs & Titres', `
+            <div class="rank-list">
+                ${this.ranks.map(rank => `
+                    <div class="rank-item">
+                        <div class="rank-insignia" style="background: ${rank.color}">${rank.badge}</div>
+                        <div>
+                            <h4>${rank.name} - <span class="rank-title">${rank.title}</span></h4>
+                            <p>À partir de ${rank.minXP} XP</p>
+                        </div>
+                    </div>
+                `).join('')}
+            </div>
+        `);
+
+        document.body.appendChild(modal);
+        this.showModal();
     }
     
     getIntensityLevel() {

--- a/styles.css
+++ b/styles.css
@@ -899,6 +899,25 @@ body {
     margin: 0 auto var(--spacing-lg);
 }
 
+.rank-btn {
+    padding: var(--spacing-lg) var(--spacing-2xl);
+    border: none;
+    border-radius: var(--border-radius);
+    background: linear-gradient(45deg, var(--accent-blue), var(--accent-purple));
+    color: white;
+    font-family: var(--font-body);
+    font-weight: 600;
+    font-size: 1.1rem;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    display: block;
+    margin: 0 auto var(--spacing-lg);
+}
+
+.rank-btn:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-glow);
+}
 .review-btn:hover {
     transform: translateY(-2px);
     box-shadow: var(--shadow-glow-purple);
@@ -1068,6 +1087,48 @@ body {
 .progression-stats .stat-card p {
     margin-bottom: var(--spacing-sm);
     color: var(--text-secondary);
+}
+
+/* Liste des rangs */
+.rank-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-lg);
+}
+
+.rank-item {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-md);
+    padding: var(--spacing-md);
+    background: linear-gradient(135deg, var(--secondary-bg) 0%, var(--tertiary-bg) 100%);
+    border: 1px solid rgba(0, 212, 255, 0.2);
+    border-radius: var(--border-radius-lg);
+    box-shadow: var(--shadow-md);
+}
+
+.rank-item .rank-insignia {
+    width: 50px;
+    height: 50px;
+    border-radius: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: var(--font-title);
+    font-size: 1.2rem;
+    color: white;
+    box-shadow: inset 0 2px 4px rgba(255, 255, 255, 0.2), inset 0 -2px 4px rgba(0, 0, 0, 0.5);
+}
+
+.rank-item h4 {
+    margin: 0;
+    font-family: var(--font-title);
+    color: var(--accent-blue);
+}
+.rank-item p {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: 0.9rem;
 }
 
 .weekly-scores {


### PR DESCRIPTION
## Summary
- show correct sign for XP changes in recent activity
- add Rangs et Titres button to the Progression tab
- display ranks and titles in a modal

## Testing
- `node -c script.js`


------
https://chatgpt.com/codex/tasks/task_e_6871988f59788332a819d9e8aafa1327