### PR TITLE
Add project management and Google Calendar sync

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,6 +66,10 @@
                 <i class="fas fa-chart-line"></i>
                 <span>Progression</span>
             </button>
+            <button class="nav-btn" data-section="projects">
+                <i class="fas fa-folder-open"></i>
+                <span>Projets</span>
+            </button>
             <button class="nav-btn" data-section="settings">
                 <i class="fas fa-cog"></i>
                 <span>Paramètres</span>
@@ -153,6 +157,12 @@
                                 <label for="focusDuration">Durée (minutes):</label>
                                 <input type="range" id="focusDuration" min="15" max="120" value="25" step="5">
                                 <span id="durationDisplay">25 min</span>
+                            </div>
+                            <div class="project-selection">
+                                <label for="projectSelect">Projet :</label>
+                                <select id="projectSelect">
+                                    <option value="">Aucun</option>
+                                </select>
                             </div>
                         </div>
                         
@@ -306,6 +316,18 @@
                 </div>
             </section>
 
+            <!-- Section Projets -->
+            <section id="projects" class="content-section">
+                <div class="projects-container">
+                    <h2>Gestion de Projets</h2>
+                    <div class="project-add">
+                        <input type="text" id="newProjectName" placeholder="Nom du projet">
+                        <button id="addProjectBtn">Ajouter</button>
+                    </div>
+                    <ul class="project-list" id="projectList"></ul>
+                </div>
+            </section>
+
             <!-- Section Paramètres -->
             <section id="settings" class="content-section">
                 <div class="settings-container">
@@ -343,6 +365,7 @@
     <div id="notificationContainer" class="notification-container"></div>
 
     <!-- Scripts -->
+    <script src="https://apis.google.com/js/api.js"></script>
     <script src="script.js"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1656,6 +1656,55 @@ body {
     pointer-events: none;
 }
 
+/* Gestion de projets */
+.project-selection {
+    margin: var(--spacing-md) 0;
+}
+
+.project-selection select {
+    padding: var(--spacing-xs);
+    border-radius: var(--border-radius);
+    background: var(--primary-bg);
+    color: var(--text-primary);
+}
+
+.projects-container {
+    max-width: 600px;
+    margin: 0 auto;
+}
+
+.project-add {
+    display: flex;
+    gap: var(--spacing-sm);
+    margin-bottom: var(--spacing-lg);
+}
+
+.project-list {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-sm);
+}
+
+.project-item {
+    background: linear-gradient(135deg, var(--secondary-bg) 0%, var(--tertiary-bg) 100%);
+    border: 1px solid rgba(0, 212, 255, 0.2);
+    border-radius: var(--border-radius);
+    padding: var(--spacing-md);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.project-item button {
+    background: var(--danger-red);
+    border: none;
+    color: white;
+    padding: 0 var(--spacing-sm);
+    border-radius: var(--border-radius);
+    cursor: pointer;
+}
+
 .overflow-hidden {
     overflow: hidden;
 }


### PR DESCRIPTION
## Summary
- add navigation tab for project management
- allow selecting a project when starting focus
- manage projects (add/remove) in a new section
- integrate Google Calendar via gapi and log 20min+ sessions
- style project management elements

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_687268599e908332ae584d031ae67b4d