### PR TITLE
Add .gitignore to keep build artifacts out of repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,2 +1,36 @@
 # MyRPGLife-Pr-f
-Mon app gamifié pour garder une trace sur ma productivité et rendre la discipline ludique
+
+Mon app gamifiée pour suivre ma productivité de manière ludique.
+
+Cette version fournit une configuration **Electron** afin de transformer l'application web en application desktop.
+
+## Lancer en mode développement
+
+```bash
+npm install
+npm start
+```
+
+## Générer l'exécutable Windows
+
+```bash
+npm run dist
+```
+
+Cela produira un installeur `.exe` dans le dossier `dist/`.
+
+## Structure des dossiers
+
+```
+MyRPGLife-Pr-f/
+├── assets/             # ressources (icône ...)
+│   └── icon.ico        # votre icône personnalisée
+├── index.html          # votre application web existante
+├── styles.css
+├── script.js
+├── main.js             # processus principal Electron
+├── package.json
+└── README.md
+```
+
+Placez votre icône personnalisée dans `assets/icon.ico` puis lancez `npm run dist` pour créer un installeur Windows avec cette icône.

--- a/assets/README.md
+++ b/assets/README.md
@@ -1,0 +1,2 @@
+Placez votre fichier d'icône Windows ici sous le nom `icon.ico`.
+Il sera utilisé par electron-builder pour générer l'exécutable Windows.

--- a/main.js
+++ b/main.js
@@ -1,0 +1,37 @@
+const { app, BrowserWindow } = require('electron');
+const path = require('path');
+
+// Function to create the main application window
+function createWindow () {
+  // Create the browser window
+  const mainWindow = new BrowserWindow({
+    width: 1000,
+    height: 800,
+    webPreferences: {
+      // Enable Node.js integration
+      nodeIntegration: true,
+      contextIsolation: false
+    }
+  });
+
+  // Load the index.html of the app
+  mainWindow.loadFile(path.join(__dirname, 'index.html'));
+
+  // Optionally open DevTools in development
+  // mainWindow.webContents.openDevTools();
+}
+
+// Create window when Electron has finished initialization
+app.whenReady().then(() => {
+  createWindow();
+
+  // Re-create a window when the app is activated (macOS)
+  app.on('activate', function () {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+// Quit when all windows are closed, except on macOS
+app.on('window-all-closed', function () {
+  if (process.platform !== 'darwin') app.quit();
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "myrpglife",
+  "version": "1.0.0",
+  "description": "Application desktop Electron pour MyRPGLife",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron .",
+    "pack": "electron-builder --dir",
+    "dist": "electron-builder"
+  },
+  "devDependencies": {
+    "electron": "^26.2.1",
+    "electron-builder": "^24.6.0"
+  },
+  "build": {
+    "appId": "com.example.myrpglife",
+    "productName": "MyRPGLife",
+    "files": [
+      "**/*"
+    ],
+    "directories": {
+      "buildResources": "assets"
+    },
+    "win": {
+      "target": "nsis",
+      "icon": "assets/icon.ico"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- ignore `node_modules`, `dist` output, and `package-lock.json`

## Testing
- `npm install`
- `npm start -- --no-sandbox` *(fails: DISPLAY not set)*
- `npm run dist`

------
https://chatgpt.com/codex/tasks/task_e_68726cd8e2348332ac71725e15f5a930